### PR TITLE
Add tapered evaluation with piece-square tables

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -11,16 +11,115 @@ PIECE_VALUES = {
     chess.KING: 0,
 }
 
+# Piece-square tables for midgame (values from Sunfish)
+MG_PST = {
+    chess.PAWN: (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        78, 83, 86, 73, 102, 82, 85, 90,
+        7, 29, 21, 44, 40, 31, 44, 7,
+        -17, 16, -2, 15, 14, 0, 15, -13,
+        -26, 3, 10, 9, 6, 1, 0, -23,
+        -22, 9, 5, -11, -10, -2, 3, -19,
+        -31, 8, -7, -37, -36, -14, 3, -31,
+        0, 0, 0, 0, 0, 0, 0, 0,
+    ),
+    chess.KNIGHT: (
+        -66, -53, -75, -75, -10, -55, -58, -70,
+        -3, -6, 100, -36, 4, 62, -4, -14,
+        10, 67, 1, 74, 73, 27, 62, -2,
+        24, 24, 45, 37, 33, 41, 25, 17,
+        -1, 5, 31, 21, 22, 35, 2, 0,
+        -18, 10, 13, 22, 18, 15, 11, -14,
+        -23, -15, 2, 0, 2, 0, -23, -20,
+        -74, -23, -26, -24, -19, -35, -22, -69,
+    ),
+    chess.BISHOP: (
+        -59, -78, -82, -76, -23, -107, -37, -50,
+        -11, 20, 35, -42, -39, 31, 2, -22,
+        -9, 39, -32, 41, 52, -10, 28, -14,
+        25, 17, 20, 34, 26, 25, 15, 10,
+        13, 10, 17, 23, 17, 16, 0, 7,
+        14, 25, 24, 15, 8, 25, 20, 15,
+        19, 20, 11, 6, 7, 6, 20, 16,
+        -7, 2, -15, -12, -14, -15, -10, -10,
+    ),
+    chess.ROOK: (
+        35, 29, 33, 4, 37, 33, 56, 50,
+        55, 29, 56, 67, 55, 62, 34, 60,
+        19, 35, 28, 33, 45, 27, 25, 15,
+        0, 5, 16, 13, 18, -4, -9, -6,
+        -28, -35, -16, -21, -13, -29, -46, -30,
+        -42, -28, -42, -25, -25, -35, -26, -46,
+        -53, -38, -31, -26, -29, -43, -44, -53,
+        -30, -24, -18, 5, -2, -18, -31, -32,
+    ),
+    chess.QUEEN: (
+        6, 1, -8, -104, 69, 24, 88, 26,
+        14, 32, 60, -10, 20, 76, 57, 24,
+        -2, 43, 32, 60, 72, 63, 43, 2,
+        1, -16, 22, 17, 25, 20, -13, -6,
+        -14, -15, -2, -5, -1, -10, -20, -22,
+        -30, -6, -13, -11, -16, -11, -16, -27,
+        -36, -18, 0, -19, -15, -15, -21, -38,
+        -39, -30, -31, -13, -31, -36, -34, -42,
+    ),
+    chess.KING: (
+        4, 54, 47, -99, -99, 60, 83, -62,
+        -32, 10, 55, 56, 56, 55, 10, 3,
+        -62, 12, -57, 44, -67, 28, 37, -31,
+        -55, 50, 11, -4, -19, 13, 0, -49,
+        -55, -43, -52, -28, -51, -47, -8, -50,
+        -47, -42, -43, -79, -64, -32, -29, -32,
+        -4, 3, -14, -50, -57, -18, 13, 4,
+        17, 30, -3, -14, 6, -1, 40, 18,
+    ),
+}
+
+# Endgame piece-square tables (only king is non-zero)
+K_ENDGAME = (
+    -50,-30,-30,-30,-30,-30,-30,-50,
+    -30,-30,0,0,0,0,-30,-30,
+    -30,-10,20,30,30,20,-10,-30,
+    -30,-10,30,40,40,30,-10,-30,
+    -30,-10,30,40,40,30,-10,-30,
+    -30,-10,20,30,30,20,-10,-30,
+    -30,-20,-10,0,0,-10,-20,-30,
+    -50,-40,-30,-20,-20,-30,-40,-50,
+)
+
+EG_PST = {
+    chess.PAWN: (0,)*64,
+    chess.KNIGHT: (0,)*64,
+    chess.BISHOP: (0,)*64,
+    chess.ROOK: (0,)*64,
+    chess.QUEEN: (0,)*64,
+    chess.KING: K_ENDGAME,
+}
+
+PIECE_PHASE = {
+    chess.PAWN: 0,
+    chess.KNIGHT: 1,
+    chess.BISHOP: 1,
+    chess.ROOK: 2,
+    chess.QUEEN: 4,
+    chess.KING: 0,
+}
+TOTAL_PHASE = 24
+
 
 def evaluate(board: Board) -> int:
-    score = 0
+    mg_score = 0
+    eg_score = 0
+    phase = 0
     for square, piece in board._board.piece_map().items():
-        value = PIECE_VALUES[piece.piece_type]
-        if piece.color == chess.WHITE:
-            score += value
-        else:
-            score -= value
-    return score
+        color = 1 if piece.color == chess.WHITE else -1
+        pt = piece.piece_type
+        idx = square if piece.color == chess.WHITE else chess.square_mirror(square)
+        mg_score += color * (PIECE_VALUES[pt] + MG_PST[pt][idx])
+        eg_score += color * (PIECE_VALUES[pt] + EG_PST[pt][idx])
+        phase += PIECE_PHASE[pt]
+    phase = min(phase, TOTAL_PHASE)
+    return (mg_score * phase + eg_score * (TOTAL_PHASE - phase)) // TOTAL_PHASE
 
 
 def minimax(board: Board, depth: int, alpha: int, beta: int, maximizing: bool) -> int:


### PR DESCRIPTION
## Summary
- implement midgame and endgame piece-square tables
- blend midgame and endgame scores via tapered evaluation

## Testing
- `python3 -m py_compile engine.py board.py main.py uci.py`
- `python3 - <<'PY'
from board import Board, Move
from engine import evaluate, find_best_move
b=Board()
print(evaluate(b))
b.push(Move(12,28))
print(evaluate(b))
print(find_best_move(Board(),1))
PY`


------
https://chatgpt.com/codex/tasks/task_e_683f8aa82154832985a1a642ba180284