### PR TITLE
Allow changing search depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ improvements.
 * Precomputed pawn move and capture tables.
 * Simple sliding attack generators.
 * Zobrist hash updated after every move.
-* Engine searches at a fixed depth of 5 plies.
+* Default search depth is 5 plies but can be changed via the UCI `go depth`
+  command or the `--depth` option when running `main.py`.
 * ``perft`` validation routines relying on ``python-chess``.
 * Rotated bitboards with caching for rook and bishop rays.
 * Pseudo-legal move generation with lazy legality checks.

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import argparse
+
 from board import Board, Move, InvalidMoveError
 from engine import find_best_move
 
@@ -23,6 +25,17 @@ def move_to_str(move_from: int, move_to: int) -> str:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Play against the engine")
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=5,
+        help="search depth in plies (default: 5)",
+    )
+    args = parser.parse_args()
+
+    depth = max(1, args.depth)
+
     board = Board()
     while True:
         print(board.get_fen())
@@ -39,7 +52,7 @@ def main() -> None:
                 print(f'Invalid move: {e}')
                 continue
         else:
-            best = find_best_move(board, 5)
+            best = find_best_move(board, depth)
             if best is None:
                 print('No moves available.')
                 break


### PR DESCRIPTION
## Summary
- add CLI argument `--depth` to set engine search depth
- document variable depth functionality in the README
- ignore `__pycache__` directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faf17ad5c832987660d1d038bd9c8