### PR TITLE
Improve multi-thread search with processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Only a subset of the protocol is supported (e.g. `position` and `go depth N`).
 
 ### Threading and Multi-PV
 
-`uci.py` now supports the standard `Threads` and `MultiPV` options. Set them
-with the UCI `setoption` command to control how many worker threads are used for
+`uci.py` now supports the standard `Threads` and `MultiPV` options.  The
+engine uses multiple processes when more than one thread is requested so that it
+can take advantage of multiple CPU cores.  Set the options with the UCI
+`setoption` command to control how many worker processes are used for the root
 search and how many principal variations are reported:
 
 ```text

--- a/engine.py
+++ b/engine.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union, List, Tuple
 import chess
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from board import Board, Move, InvalidMoveError, _piece_type_from_letter
 from bitboard_utils import popcount
 
@@ -699,7 +699,7 @@ def find_best_move(
         for m in moves:
             results.append(_search_move_thread((board, m, depth)))
     else:
-        with ThreadPoolExecutor(max_workers=threads) as pool:
+        with ProcessPoolExecutor(max_workers=threads) as pool:
             futs = [pool.submit(_search_move_thread, (board, m, depth)) for m in moves]
             for f in futs:
                 results.append(f.result())


### PR DESCRIPTION
## Summary
- use `ProcessPoolExecutor` when multiple threads are requested so that the engine can run in parallel
- update documentation to mention the use of processes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb942c9ac8329b91c60ae4f29fd09