### PR TITLE
Enhance mate scoring and king safety

### DIFF
--- a/uci.py
+++ b/uci.py
@@ -55,20 +55,7 @@ def main() -> None:
         elif line == "isready":
             print("readyok")
         elif line.startswith("setoption"):
-            tokens = line.split()
-            if len(tokens) >= 5 and tokens[1] == "name" and tokens[3] == "value":
-                name = tokens[2].lower()
-                value = tokens[4]
-                if name == "threads":
-                    try:
-                        globals()["THREADS"] = max(1, int(value))
-                    except ValueError:
-                        pass
-                elif name == "multipv":
-                    try:
-                        globals()["MULTIPV"] = max(1, int(value))
-                    except ValueError:
-                        pass
+            # Options are ignored; engine runs with fixed parameters
             continue
         elif line == "ucinewgame":
             board = Board()


### PR DESCRIPTION
## Summary
- strengthen king-safety evaluation with heavier penalties for exposure and open files
- use sky‑high mate scores and negative distance-to-mate
- add mate threat extension
- ignore thread and multipv options in UCI interface

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc98fe0d08329ba2c1c80d5f67607