### PR TITLE
Fix missing math import

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -3,6 +3,7 @@ import chess
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 import multiprocessing
 import struct
+import math
 from board import Board, Move, InvalidMoveError, _piece_type_from_letter
 from bitboard_utils import popcount
 


### PR DESCRIPTION
## Summary
- import math in `engine.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd65ea0788329bdc974d07663e72e