### PR TITLE
Reduce NNUE training positions

### DIFF
--- a/train_nnue.py
+++ b/train_nnue.py
@@ -12,8 +12,8 @@ import numpy as np
 
 BERSERK_PATH = Path(__file__).with_name("berserk-13-avx2.exe")
 WEIGHTS_FILE = Path(__file__).with_name("nnue_weights.pt")
-SAMPLE_SIZE = 100_000
-DEPTH = 13
+SAMPLE_SIZE = 1_000  # number of random positions to generate
+DEPTH = 8            # Berserk evaluation depth
 BATCH_SIZE = 64
 EPOCHS = 1
 


### PR DESCRIPTION
## Summary
- limit NNUE training to 1,000 random boards
- evaluate those boards with Berserk at depth 8

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841029973f48329b00355aea5cc3b95